### PR TITLE
Revise toast message to inform user of empty content

### DIFF
--- a/src/views/NewTopic.vue
+++ b/src/views/NewTopic.vue
@@ -96,7 +96,7 @@ export default {
         .catch( ( err ) => {
           console.error( err );
           this.$toast.open( {
-            message: 'Oops! Could not create your topic at this moment.',
+            message: 'Oops! Could not create your topic at this moment. ' + err.error.message,
             type: 'is-danger',
           } );
           this.fetching = false;


### PR DESCRIPTION
Enhances the fix for https://app.clickup.com/t/cp6wj as suggested by @thecryptodrive.

E.g. the error message for an empty post would say...

`Oops could not create your topic at this moment. You need to provide some content!`

