### PR TITLE
Add links for jumping top and bottom

### DIFF
--- a/src/themes/default.scss
+++ b/src/themes/default.scss
@@ -312,6 +312,22 @@
     list-style: disc !important;
   }
 
+  /* Topic navigation buttons */
+  .topic-nav {
+    /* styles to apply to all topic navigation */
+    /* links, e.g. Jump to end, Back to top    */
+  }
+
+  .topic-nav-to-top {
+    /* styles to apply to topic navigation for */
+    /* Back to top only                            */
+  }  
+
+  .topic-nav-to-end {
+    /* styles to apply to all topic navigation for */
+    /* Jump to end only                                */
+  }   
+
   // make sure to have all sensible defaults set
   @import "./global/sensible-defaults.scss";
 

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -12,7 +12,10 @@
 
         <CategoryTag :categoryId="topic.categoryId">
         </CategoryTag>
-
+        &nbsp;
+        <a class="topic-nav topic-nav-to-end" @click="scrollTo('endOfTopic')">
+          Jump to end
+        </a>
       </header>
 
       <br>
@@ -29,7 +32,7 @@
       </main>
 
       <br>
-
+      <a ref="endOfTopic" />
       <ShowIfLoggedIn>
         <ReplyForm
           :fetching="$store.state.replies.fetching"
@@ -113,6 +116,9 @@ export default {
     },
     categoryFromId( id ) {
       return ( this.categoriesBySlug[id] || { name: '' } ).name;
+    },
+    scrollTo( refName ) {
+      window.scrollTo( 0, this.$refs[refName].offsetTop );
     },
   },
 };

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -29,6 +29,9 @@
           :key="index"
         >
         </Post>
+        <a class="topic-nav topic-nav-to-top" @click="scrollTo('posts')">
+          Back to Top
+        </a>
       </main>
 
       <br>


### PR DESCRIPTION
Closes https://app.clickup.com/t/cp1yb

# Changes proposed in this pull request:

- Two links are added, on at the top of the topic one at the end.  Clicking either link scrolls a specific `ref` into view,
- Unique classes are added for each link tag
- To keep either tag always in view this should be added to the appropriate class style dependent on theme.

Review please
