### PR TITLE
Make 'Back To Top' Link Target Top Of Page

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,6 +1,7 @@
 <template>
   <nav  id="nav" class="navbar" role="navigation" aria-label="main navigation">
     <div class="container">
+      <a id="topOfPage" />
       <div class="navbar-brand">
         <div class="navbar-item">
           <router-link

--- a/src/views/NewTopic.vue
+++ b/src/views/NewTopic.vue
@@ -38,13 +38,6 @@
             class="button is-primary">
             Create Topic
           </button>
-          &nbsp;
-          <button role="cancel"
-            @click="$emit('close_new_topic')"
-            :class="{ 'is-loading': fetching }"
-            class="button">
-            Cancel
-          </button>
         </div>
       </div>
     </form>

--- a/src/views/NewTopic.vue
+++ b/src/views/NewTopic.vue
@@ -38,6 +38,13 @@
             class="button is-primary">
             Create Topic
           </button>
+          &nbsp;
+          <button role="cancel"
+            @click="$emit('close_new_topic')"
+            :class="{ 'is-loading': fetching }"
+            class="button">
+            Cancel
+          </button>
         </div>
       </div>
     </form>

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -29,13 +29,13 @@
           :key="index"
         >
         </Post>
-        <a class="topic-nav topic-nav-to-top" @click="scrollTo('posts')">
+        <a class="topic-nav topic-nav-to-top" @click="scrollTo('topOfPage')">
           Back to Top
         </a>
       </main>
 
       <br>
-      <a ref="endOfTopic" />
+      <a id="endOfTopic" />
       <ShowIfLoggedIn>
         <ReplyForm
           :fetching="$store.state.replies.fetching"
@@ -120,8 +120,8 @@ export default {
     categoryFromId( id ) {
       return ( this.categoriesBySlug[id] || { name: '' } ).name;
     },
-    scrollTo( refName ) {
-      window.scrollTo( 0, this.$refs[refName].offsetTop );
+    scrollTo( id ) {
+      window.scrollTo( 0, document.getElementById( id ).offsetTop );
     },
   },
 };


### PR DESCRIPTION
Addresses request by @thecryptodrive to have the 'Jump to top' link on a topic target the top of the page so that the navbar brand element (i.e." home button") is made visible

# Changes proposed in this pull request:

- Added a new `<a />` element to `navbar` component to serve as a target
- Switched to using `id` attribute to designate target for `scrollTo()` because `this.$refs[]` didn't afford access to a target in a different component.

Review please
