### PR TITLE
Prevent Reposting Of Previous Reply

### DIFF
--- a/src/components/ReplyForm.vue
+++ b/src/components/ReplyForm.vue
@@ -11,6 +11,7 @@
       <div class="control">
         <button role="submit"
           class="button is-primary"
+          :disabled="text.length == 0"
           v-bind:class="{ 'is-loading': fetching }">
           Reply
         </button>

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -95,6 +95,7 @@ export default {
         .then( ( reply ) => {
           if ( reply ) {
             this.fetchTopic();
+            this.replyText = '';
           }
         } )
         .catch( ( err ) => {


### PR DESCRIPTION
### Closes [Hitting Reply without typing reposts previous comment](https://app.clickup.com/t/cp5ew)

## Changes proposed in this pull request:

- Clear the text of the previous reply in `data` after posting
- BONUS protection - disable Reply button until text is entered

Review please
