### PR TITLE
Commit The Nested Data Instead Of The Response

### DIFF
--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -33,7 +33,7 @@ export default {
 
       addCategory( categoryName, title, description )
         .then( ( category ) => {
-          commit( 'add', category );
+          commit( 'add', category.data );
           commit( 'setFetching', false );
         } )
         .catch( ( err ) => {


### PR DESCRIPTION
## Closes: [Add Category needs autorefresh](https://app.clickup.com/t/hgu18)

# Changes proposed in this pull request:

Formerly the response object as a whole was being pushed onto the table's `data()`. I modified the callback in `addCategory()` so that only the new category's information, which is nested inside the response, would be pushed on instead.

Review please
