### PR TITLE
Move addQuote Function To TextEditor.methods

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -25,17 +25,18 @@ export default {
       },
     };
   },
+  methods: {
+    addQuote( quote ) {
+      this.content += `\n> @${ quote.author.user }:\n${ quote.body.replace( /^/gm, '> ' ) }\n---\n`;
+    }
+  },
   watch: {
     content() {
       this.$emit( 'input', this.content );
     },
   },
   created() {
-    this.$root.$on( 'quote-click', addQuote );
-
-    function addQuote( d ) {
-      this.content += `\n> @${ d.author.user }:\n${ d.body.replace( /^/gm, '> ' ) }\n---\n`;
-    }
+    this.$root.$on( 'quote-click', this.addQuote );
   },
 };
 </script>


### PR DESCRIPTION
This is suggested to make quoting work again after a recent change.

When the event handler was refactored `this` inside `addQuote()` no longer refered to the parent component:

```js
    this.$root.$on( 'quote-click', addQuote );
    function addQuote( d ) {
      this.content += `string_omitted_for_brevity`;
    }
```

An alternative approach to the one in this pull request would be:

```js
    this.$root.$on( 'quote-click', addQuote );
    this.self = this;

    function addQuote( d ) {
      self.content += `string_omitted_for_brevity`;
    }
```

Or binding

```js
    this.$root.$on( 'quote-click', addQuote.bind(this) );

    function addQuote( d ) {
      this.content += `string_omitted_for_brevity`;
    }
```
