### PR TITLE
Allow editing of categories (not the slug)

### DIFF
--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -128,6 +128,20 @@ export function addCategory( categoryName, title, description ) {
   return requestAsync( opts );
 }
 
+export function editCategory( category ) {
+  const opts = {
+    method: 'POST',
+    json: true,
+    headers: steem.token ? { 'Authorization': 'Bearer ' + steem.token } : {},
+    url: `${apiURL()}/${category.slug}/edit`,
+    body: {
+      ...category,
+    },
+  };
+
+  return requestAsync( opts );
+}
+
 export function removeCategory( categoryName ) {
   const opts = {
     method: 'DELETE',

--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -1,6 +1,6 @@
 import { Toast } from 'buefy/dist/components/toast';
 
-import { addCategory, listCategories, removeCategory } from '../services/api.service';
+import { addCategory, editCategory, listCategories, removeCategory } from '../services/api.service';
 import { errorAlertOptions } from '../utils/notifications.js';
 
 import map from 'lodash/map';
@@ -116,7 +116,19 @@ export default {
 
       addCategory( categoryName, title, description )
         .then( ( category ) => {
-          commit( 'add', category.data );
+          commit( 'setFetching', false );
+        } )
+        .catch( ( err ) => {
+          commit( 'setFetching', false );
+          Toast.open( errorAlertOptions( `Error adding category ${categoryName}`, err ) );
+          console.error( err );
+        } );
+    },
+    edit( { commit }, category ) {
+      commit( 'setFetching', true );
+
+      editCategory( category )
+        .then( ( cat ) => {
           commit( 'setFetching', false );
         } )
         .catch( ( err ) => {
@@ -130,7 +142,6 @@ export default {
 
       removeCategory( category.name )
         .then( () => {
-          commit( 'remove', category );
           commit( 'setFetching', false );
         } )
         .catch( ( err ) => {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -8,7 +8,7 @@
 
     <b-table
       class="setting-page"
-      :data="categoryList"
+      :data="categoryRows"
       mobile-cards
     >
       <template slot-scope="props">
@@ -23,19 +23,87 @@
           field="name"
           label="Name"
         >
-          {{ props.row.name }}
+          <b-field
+            v-if="props.row.edit"
+          >
+            <b-input
+              v-model="props.row.edit.name"
+              :maxlength="32"
+              :has-counter="false"
+            />
+          </b-field>
+          <div
+            v-else
+          >
+            {{ props.row.name }}
+          </div>
         </b-table-column>
         <b-table-column
           field="title"
           label="Title"
         >
-          {{ props.row.title }}
+          <b-field
+            v-if="props.row.edit"
+          >
+            <b-input
+              v-model="props.row.edit.title"
+              :maxlength="32"
+              :has-counter="false"
+            />
+          </b-field>
+          <div
+            v-else
+          >
+            {{ props.row.title }}
+          </div>
         </b-table-column>
         <b-table-column
           field="description"
           label="Description"
         >
-          {{ props.row.description }}
+          <b-field
+            v-if="props.row.edit"
+          >
+            <b-input
+              v-model="props.row.edit.description"
+              :maxlength="320"
+              :has-counter="false"
+            />
+          </b-field>
+          <div
+            v-else
+          >
+            {{ props.row.description }}
+          </div>
+        </b-table-column>
+        <b-table-column
+          label="Action"
+          width="150"
+        >
+          <button
+            v-if="props.row.edit"
+            class="button is-small"
+            style="min-width: 40px; max-width: 40px ; width: 40px"
+            :class="{ 'is-loading': fetching }"
+            :disabled="fetching"
+            @click="save(props.row.slug)"
+          >
+            Save
+          </button>
+          <button
+            class="button is-small"
+            style="min-width: 40px; max-width: 40px ; width: 40px"
+            :class="{ 'is-loading': fetching }"
+            :disabled="fetching"
+            @click="toggleEdit(props.row.slug)"
+          >
+            <div v-if="props.row.edit">
+              Cancel
+            </div>
+            <div v-else>
+              Edit
+            </div>
+          </button>
         </b-table-column>
         <!--
         <b-table-column label="Delete" centered>
@@ -100,6 +168,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import { mapState } from 'vuex';
 
 import Table from 'buefy/src/components/table/Table';
@@ -120,6 +189,7 @@ export default {
       name: '',
       title: '',
       description: '',
+      editing: {},
     };
   },
   computed: {
@@ -127,8 +197,28 @@ export default {
       'categoryList',
       'fetching',
     ] ),
+    categoryRows() {
+      return this.categoryList.map( ( c ) => {
+        if ( this.editing[c.slug] ) {
+          return {
+            ...c,
+            edit: this.editing[c.slug],
+          };
+        }
+        return c;
+
+      } );
+    },
   },
   methods: {
+    toggleEdit( slug ) {
+      const thisCategory = this.categoryList.find( ( c ) => c.slug === slug );
+      if ( !this.editing[slug] ) {
+        Vue.set( this.editing, slug, { ...thisCategory } );
+      } else {
+        Vue.set( this.editing, slug, null );
+      }
+    },
     add() {
       this.$store.dispatch( 'categories/add', {
         name: this.name,
@@ -143,6 +233,18 @@ export default {
         } )
         .catch( ( err ) => {
           console.error( err );
+          this.fetching = false;
+        } );
+    },
+    save( slug ) {
+      this.$store.dispatch( 'categories/edit', this.editing[slug] )
+        .then( () => {
+          this.editing[slug] = null;
+          this.$store.dispatch( 'categories/fetchAll' );
+        } )
+        .catch( ( err ) => {
+          console.error( err );
+          this.editing[slug] = null;
           this.fetching = false;
         } );
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -168,13 +168,13 @@
 </template>
 
 <script>
-import Vue from 'vue';
-import { mapState } from 'vuex';
+import Field from 'buefy/src/components/field/Field';
+import Input from 'buefy/src/components/input/Input';
 
 import Table from 'buefy/src/components/table/Table';
 import TableColumn from 'buefy/src/components/table/TableColumn';
-import Field from 'buefy/src/components/field/Field';
-import Input from 'buefy/src/components/input/Input';
+import Vue from 'vue';
+import { mapState } from 'vuex';
 
 export default {
   name: 'Settings',
@@ -229,7 +229,7 @@ export default {
           this.name = '';
           this.title = '';
           this.description = '';
-          this.$store.dispatch( 'categories/fetchAll' );
+          this.$nextTick( () => this.$store.dispatch( 'categories/fetchAll' ) );
         } )
         .catch( ( err ) => {
           console.error( err );
@@ -240,9 +240,8 @@ export default {
       this.$store.dispatch( 'categories/edit', this.editing[slug] )
         .then( () => {
           this.editing[slug] = null;
-          this.$store.dispatch( 'categories/fetchAll' );
-        } )
-        .catch( ( err ) => {
+          this.$nextTick( () => this.$store.dispatch( 'categories/fetchAll' ) );
+        }, ( err ) => {
           console.error( err );
           this.editing[slug] = null;
           this.fetching = false;
@@ -250,7 +249,7 @@ export default {
     },
     remove( category ) {
       this.$store.dispatch( 'categories/remove', category )
-        .then( () => this.$store.dispatch( 'categories/fetchAll' ) )
+        .then( () => this.$nextTick( () => this.$store.dispatch( 'categories/fetchAll' ) ) )
         .catch( ( err ) => {
           console.error( err );
           this.fetching = false;


### PR DESCRIPTION
# Changes proposed in this pull request:

- Clicking edit will expose input boxes, which can then be filled in. Hitting save sends request to save, and cancel will revert.
- Also prevents double-rows appearing on category add.
- Assumes /edit endpoint in API.

![Screenshot 2019-04-17 at 3 00 49 PM](https://user-images.githubusercontent.com/34953718/56314023-f7293a00-6121-11e9-815c-065c84b969c0.png)
