### PR TITLE
Allow changing category order and adding categories into the ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4507,6 +4507,23 @@
       "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
       "dev": true
     },
+    "drag-event-service": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/drag-event-service/-/drag-event-service-0.0.6.tgz",
+      "integrity": "sha512-ScjnHbcMvO0abUKRc5JJKa5eqWUJ+eGaoti8RRnAG++NK3oCIMfSpLs0smcugf/DBNbD9QornGmwFIvcugHEzw==",
+      "requires": {
+        "helper-js": "^1.2.0"
+      }
+    },
+    "draggable-helper": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/draggable-helper/-/draggable-helper-1.0.20.tgz",
+      "integrity": "sha512-/ym423hF2cIAIjhPj0SvDClg9aWvhWXxy0eABaXRo3Ofx2IQrsJdwb53geiyLxBQR63owjEHSVeLhjP/DQTq8A==",
+      "requires": {
+        "drag-event-service": "0.0.6",
+        "helper-js": "^1.3.7"
+      }
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -5741,8 +5758,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5763,14 +5779,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5785,20 +5799,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5915,8 +5926,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5928,7 +5938,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5943,7 +5952,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5951,14 +5959,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5977,7 +5983,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6058,8 +6063,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6071,7 +6075,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6157,8 +6160,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6194,7 +6196,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6214,7 +6215,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6258,14 +6258,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6643,6 +6641,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "helper-js": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/helper-js/-/helper-js-1.3.9.tgz",
+      "integrity": "sha512-Gdz62g20R88TfqdsusHfZOXywJUx87YiCYwtQaAq4dS0Lk7rX0nQFR088ZiduVBbLtUkEPjzLJGnN4z9cSHmGw=="
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -12334,6 +12337,14 @@
         }
       }
     },
+    "tree-helper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tree-helper/-/tree-helper-1.0.5.tgz",
+      "integrity": "sha512-R7L2QXJqW34aBT6ojMnDSp4+DnGrP62YVAVZnXNCRFCEGuPct+18/CaxUFRAl9nsyw7qVu8odhShSSc++1QBPg==",
+      "requires": {
+        "helper-js": "^1.0.47"
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -12755,6 +12766,18 @@
       "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.16.4.tgz",
       "integrity": "sha512-M67cUqpPeyk2rftrvlx2uU+BQ/C4E8SkF2Ct9LizOYUoTccZtCCJwhMJfQ3XL8xep6p3K8KYz58FzRWvx5zlPw=="
     },
+    "vue-draggable-nested-tree": {
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/vue-draggable-nested-tree/-/vue-draggable-nested-tree-2.2.17.tgz",
+      "integrity": "sha512-xM+Zua9g7O+jYyO3pe7WC47XpriPkZpn+zl04jD90IhA2EnXp1xl30ilfV3sVouSK8vj4mIyRet4ydJjxIzKlA==",
+      "requires": {
+        "draggable-helper": "^1.0.20",
+        "helper-js": "^1.3.7",
+        "tree-helper": "^1.0.5",
+        "vue": "^2.5.21",
+        "vue-functions": "^1.0.3"
+      }
+    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
@@ -12798,6 +12821,14 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "vue-functions": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vue-functions/-/vue-functions-1.0.3.tgz",
+      "integrity": "sha512-2Z+QpivGLBcTtMwC/BNNvn86pR/c8Yf/LzEfONlVdMhql3uxiV/NlE7WErh9fp5vwAzlEQuOl0CPrRrEth0OWQ==",
+      "requires": {
+        "helper-js": "^1.3.1"
       }
     },
     "vue-hot-reload-api": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "steem-editor": "^1.0.9",
     "vue": "^2.6.8",
     "vue-analytics": "^5.16.4",
+    "vue-draggable-nested-tree": "^2.2.17",
     "vue-router": "^3.0.2",
     "vuex": "^3.1.0"
   },

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -31,29 +31,6 @@
       class="navbar-menu"
       :class="{ 'is-active': menuActive }"
     >
-      <div class="navbar-start">
-        <div class="navbar-item">
-          <!--<p class="tr is-right">
-              <router-link
-                      v-if="auth.username"
-                      to="/create-forum"
-                      class="navbar-item is-primary">
-                Create Forum
-              </router-link>
-            </p>-->
-          <div>
-            <a>
-              <router-link
-                v-if="auth.roles.admin"
-                to="/settings"
-              >
-                Settings
-              </router-link>
-            </a>
-          </div>
-        </div>
-      </div>
-
       <div class="navbar-end">
         <div class="navbar-item is-expanded tr">
           <div class="nav-account">
@@ -91,7 +68,12 @@
             <span>Account</span>
             <b-icon icon="menu-down" />
           </button>
-
+          <b-dropdown-item
+            v-if="auth.roles.admin"
+            href="/settings"
+          >
+            Forum Settings
+          </b-dropdown-item>
           <b-dropdown-item
             class="is-right"
             @click="auth.addLink"

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ import { errorAlertOptions } from './utils/notifications.js';
 registerSW();
 
 const contextMap = {
-  default: { theme: 'theme-default', forum: 'support', icon: 'favicon.ico' },
+  default: { theme: 'theme-default', forum: 'test', icon: 'favicon.ico' },
   monsters: { theme: 'theme-monsters', forum: 'monsters', icon: 'themes/monsters/favicon_teeth.png' },
   drugwars: { theme: 'theme-drugwars', forum: 'drugwars', icon: 'themes/drugwars/small.png' },
   localhost: { theme: 'theme-default', forum: 'test', icon: 'favicon.ico' },

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -125,7 +125,7 @@ export function createForum( forumName, admin ) {
   return requestAsync( opts );
 }
 
-export function addCategory( categoryName, title, description ) {
+export function addCategory( categoryName, title, description, nav ) {
   const opts = {
     method: 'POST',
     json: true,
@@ -135,6 +135,7 @@ export function addCategory( categoryName, title, description ) {
       name: categoryName,
       title,
       description,
+      nav,
     },
   };
 
@@ -161,6 +162,20 @@ export function removeCategory( categoryName ) {
     json: true,
     headers: steem.token ? { 'Authorization': 'Bearer ' + steem.token } : {},
     url: apiURL() + '/categories/' + categoryName,
+  };
+
+  return requestAsync( opts );
+}
+
+export function setCategoryOrdering( categoryOrdering ) {
+  const opts = {
+    method: 'POST',
+    json: true,
+    headers: steem.token ? { 'Authorization': 'Bearer ' + steem.token } : {},
+    url: `${apiURL()}/categoryOrdering`,
+    body: {
+      categoryOrdering: JSON.stringify( categoryOrdering ),
+    },
   };
 
   return requestAsync( opts );

--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -2,30 +2,9 @@ import { Toast } from 'buefy/dist/components/toast';
 
 import { addCategory, editCategory, listCategories, removeCategory } from '../services/api.service';
 import { errorAlertOptions } from '../utils/notifications.js';
+import { stringToSlug } from '../utils/slug.js';
 
 import map from 'lodash/map';
-
-function stringToSlug( inputStr ) {
-  let str = String( inputStr );
-  str = str.trim();
-  str = str.toLowerCase();
-
-  // remove accents, swap ñ for n, etc
-  const from = 'åàáãäâèéëêìíïîòóöôùúüûñç·/_,:;';
-  const to = 'aaaaaaeeeeiiiioooouuuunc------';
-
-  for ( let i = 0, l = from.length; i < l; i++ ) {
-    str = str.replace( new RegExp( from.charAt( i ), 'g' ), to.charAt( i ) );
-  }
-
-  return str
-    .replace( /[^a-z0-9 -]/g, '' ) // remove invalid chars
-    .replace( /\s+/g, '-' ) // collapse whitespace and replace by -
-    .replace( /-+/g, '-' ) // collapse dashes
-    .replace( /^-+/, '' ) // trim - from start of text
-    .replace( /-+$/, '' ) // trim - from end of text
-    .substring( 0, 24 );
-}
 
 function computeCategoryOrderingData( state, categoryOrdering ) {
   const categoriesBySlug = {};

--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -117,18 +117,16 @@ export default {
     },
   },
   actions: {
-    add( { commit }, { name: categoryName, title, description, nav } ) {
+    async add( { commit }, { name: categoryName, title, description, nav } ) {
       commit( 'setFetching', true );
-
-      addCategory( categoryName, title, description, nav )
-        .then( () => {
-          commit( 'setFetching', false );
-        } )
-        .catch( ( err ) => {
-          commit( 'setFetching', false );
-          Toast.open( errorAlertOptions( `Error adding category ${categoryName}`, err ) );
-          console.error( err );
-        } );
+      try {
+        await addCategory( categoryName, title, description, nav );
+      } catch ( err ) {
+        Toast.open( errorAlertOptions( `Error adding category ${categoryName}`, err ) );
+        console.error( err );
+      } finally {
+        commit( 'setFetching', false );
+      }
     },
     edit( { commit }, category ) {
       commit( 'setFetching', true );

--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -5,6 +5,88 @@ import { errorAlertOptions } from '../utils/notifications.js';
 
 import map from 'lodash/map';
 
+function stringToSlug( inputStr ) {
+  let str = String( inputStr );
+  str = str.trim();
+  str = str.toLowerCase();
+
+  // remove accents, swap ñ for n, etc
+  const from = 'åàáãäâèéëêìíïîòóöôùúüûñç·/_,:;';
+  const to = 'aaaaaaeeeeiiiioooouuuunc------';
+
+  for ( let i = 0, l = from.length; i < l; i++ ) {
+    str = str.replace( new RegExp( from.charAt( i ), 'g' ), to.charAt( i ) );
+  }
+
+  return str
+    .replace( /[^a-z0-9 -]/g, '' ) // remove invalid chars
+    .replace( /\s+/g, '-' ) // collapse whitespace and replace by -
+    .replace( /-+/g, '-' ) // collapse dashes
+    .replace( /^-+/, '' ) // trim - from start of text
+    .replace( /-+$/, '' ) // trim - from end of text
+    .substring( 0, 24 );
+}
+
+function computeCategoryOrderingData( state, categoryOrdering ) {
+  const categoriesBySlug = {};
+  state.categoryList.forEach( ( category ) => {
+    state.categoriesById[category._id] = category;
+    categoriesBySlug[category.slug] = category;
+  } );
+
+  const categoryGroupsByNav = {};
+  function processCategoryOrdering( ordering, nav = '' ) {
+    const slug = stringToSlug( ordering.slug );
+    const currentNav = nav + ( nav !== '' ? '/' : '' ) + slug;
+    const categoryGroup = { name: ordering.name, nav: currentNav, slug: ordering.slug };
+    categoryGroupsByNav[currentNav] = categoryGroup;
+    categoryGroup.groups = map( ordering.groups, ( g ) => {
+      return processCategoryOrdering( g, currentNav );
+    } );
+    categoryGroup.categories = map( ordering.categories, ( c ) => {
+      const found = categoriesBySlug[c];
+      if ( found ) {
+        found.nav = currentNav;
+        categoriesBySlug[c] = null;
+      }
+      return found;
+    } ).filter( ( c ) => c );
+    return categoryGroup;
+  }
+
+  let homeCategory = {
+    name: 'Home',
+    nav: 'home',
+    slug: 'home',
+    groups: [],
+    categories: [],
+  };
+
+  // when getter not ready, categoryOrdering is a function
+  if ( categoryOrdering && typeof categoryOrdering === 'object' ) {
+    if ( Array.isArray( categoryOrdering ) ) {
+      homeCategory.groups = categoryOrdering;
+      homeCategory = processCategoryOrdering( homeCategory );
+    } else {
+      homeCategory = processCategoryOrdering( categoryOrdering );
+    }
+  }
+
+  // Place other categories on root level.
+  homeCategory.categories = Object.values( categoriesBySlug )
+    .filter( ( c ) => c )
+    .map( ( c ) => {
+      c.nav = 'home';
+      return c;
+    } );
+  homeCategory.categoryGroupsByNav = categoryGroupsByNav;
+
+  state.categoriesByBreadcrumb = homeCategory;
+
+  // For Vue Reactivity.
+  state.categoriesById = { ...state.categoriesById };
+}
+
 export default {
   namespaced: true,
   state: {
@@ -27,94 +109,18 @@ export default {
     },
     updateCategoryList( state, categories ) {
       state.categoryList = categories;
-      const categoriesBySlug = {};
-      categories.forEach( ( category ) => {
-        state.categoriesById[category._id] = category;
-        categoriesBySlug[category.slug] = category;
-      } );
 
-      const categoryOrdering = this.getters['forum/getCategoryOrdering'];
-
-      function stringToSlug( inputStr ) {
-        let str = String( inputStr );
-        str = str.trim();
-        str = str.toLowerCase();
-
-        // remove accents, swap ñ for n, etc
-        const from = 'åàáãäâèéëêìíïîòóöôùúüûñç·/_,:;';
-        const to = 'aaaaaaeeeeiiiioooouuuunc------';
-
-        for ( let i = 0, l = from.length; i < l; i++ ) {
-          str = str.replace( new RegExp( from.charAt( i ), 'g' ), to.charAt( i ) );
-        }
-
-        return str
-          .replace( /[^a-z0-9 -]/g, '' ) // remove invalid chars
-          .replace( /\s+/g, '-' ) // collapse whitespace and replace by -
-          .replace( /-+/g, '-' ) // collapse dashes
-          .replace( /^-+/, '' ) // trim - from start of text
-          .replace( /-+$/, '' ) // trim - from end of text
-          .substring( 0, 24 );
-      }
-
-      const categoryGroupsByNav = {};
-      function processCategoryOrdering( ordering, nav = '' ) {
-        const slug = stringToSlug( ordering.slug );
-        const currentNav = nav + ( nav !== '' ? '/' : '' ) + slug;
-        const categoryGroup = { name: ordering.name, nav: currentNav };
-        categoryGroupsByNav[currentNav] = categoryGroup;
-        categoryGroup.groups = map( ordering.groups, ( g ) => {
-          return processCategoryOrdering( g, currentNav );
-        } );
-        categoryGroup.categories = map( ordering.categories, ( c ) => {
-          const found = categoriesBySlug[c];
-          if ( found ) {
-            found.nav = currentNav;
-            categoriesBySlug[c] = null;
-          }
-          return found;
-        } ).filter( ( c ) => c );
-        return categoryGroup;
-      }
-
-      let homeCategory = {
-        name: 'Home',
-        nav: 'home',
-        slug: 'home',
-        groups: [],
-        categories: [],
-      };
-
-      // when getter not ready, categoryOrdering is a function
-      if ( categoryOrdering && typeof categoryOrdering === 'object' ) {
-        if ( Array.isArray( categoryOrdering ) ) {
-          homeCategory.groups = categoryOrdering;
-          homeCategory = processCategoryOrdering( homeCategory );
-        } else {
-          homeCategory = processCategoryOrdering( categoryOrdering );
-        }
-      }
-
-      // Place other categories on root level.
-      homeCategory.categories = Object.values( categoriesBySlug )
-        .filter( ( c ) => c )
-        .map( ( c ) => {
-          c.nav = 'home';
-          return c;
-        } );
-      homeCategory.categoryGroupsByNav = categoryGroupsByNav;
-
-      state.categoriesByBreadcrumb = homeCategory;
-
-      // For Vue Reactivity.
-      state.categoriesById = { ...state.categoriesById };
+      computeCategoryOrderingData( state, this.getters['forum/getCategoryOrdering'] );
+    },
+    updateCategoryOrderingData( state ) {
+      computeCategoryOrderingData( state, this.getters['forum/getCategoryOrdering'] );
     },
   },
   actions: {
-    add( { commit }, { name: categoryName, title, description } ) {
+    add( { commit }, { name: categoryName, title, description, nav } ) {
       commit( 'setFetching', true );
 
-      addCategory( categoryName, title, description )
+      addCategory( categoryName, title, description, nav )
         .then( () => {
           commit( 'setFetching', false );
         } )

--- a/src/store/forum.store.js
+++ b/src/store/forum.store.js
@@ -1,6 +1,6 @@
 import { Toast } from 'buefy/dist/components/toast';
 
-import { listRoles } from '../services/api.service.js';
+import { listRoles, setCategoryOrdering } from '../services/api.service.js';
 import { errorAlertOptions } from '../utils/notifications.js';
 
 
@@ -25,6 +25,7 @@ export default {
       }
       state.owners = forum.owners;
       state.mods = forum.mods;
+      this.commit( 'categories/updateCategoryOrderingData' );
     },
   },
   getters: {
@@ -50,6 +51,17 @@ export default {
         .catch( ( err ) => {
           commit( 'setFetching', false );
           Toast.open( errorAlertOptions( 'Error fetching forum', err ) );
+          console.error( err );
+        } );
+    },
+    editCategoryOrdering( { commit }, categoryOrdering ) {
+      commit( 'setFetching', true );
+      setCategoryOrdering( categoryOrdering )
+        .then( () => {
+          commit( 'setFetching', false );
+        }, ( err ) => {
+          commit( 'setFetching', false );
+          Toast.open( errorAlertOptions( 'Error editing category ordering', err ) );
           console.error( err );
         } );
     },

--- a/src/store/forum.store.js
+++ b/src/store/forum.store.js
@@ -54,16 +54,16 @@ export default {
           console.error( err );
         } );
     },
-    editCategoryOrdering( { commit }, categoryOrdering ) {
+    async editCategoryOrdering( { commit }, categoryOrdering ) {
       commit( 'setFetching', true );
-      setCategoryOrdering( categoryOrdering )
-        .then( () => {
-          commit( 'setFetching', false );
-        }, ( err ) => {
-          commit( 'setFetching', false );
-          Toast.open( errorAlertOptions( 'Error editing category ordering', err ) );
-          console.error( err );
-        } );
+      try {
+        await setCategoryOrdering( categoryOrdering );
+      } catch ( err ) {
+        Toast.open( errorAlertOptions( 'Error editing category ordering', err ) );
+        console.error( err );
+      } finally {
+        commit( 'setFetching', false );
+      }
     },
   },
 };

--- a/src/utils/slug.js
+++ b/src/utils/slug.js
@@ -1,0 +1,21 @@
+export function stringToSlug( inputStr ) {
+  let str = String( inputStr );
+  str = str.trim();
+  str = str.toLowerCase();
+
+  // remove accents, swap ñ for n, etc
+  const from = 'åàáãäâèéëêìíïîòóöôùúüûñç·/_,:;';
+  const to = 'aaaaaaeeeeiiiioooouuuunc------';
+
+  for ( let i = 0, l = from.length; i < l; i++ ) {
+    str = str.replace( new RegExp( from.charAt( i ), 'g' ), to.charAt( i ) );
+  }
+
+  return str
+    .replace( /[^a-z0-9 -]/g, '' ) // remove invalid chars
+    .replace( /\s+/g, '-' ) // collapse whitespace and replace by -
+    .replace( /-+/g, '-' ) // collapse dashes
+    .replace( /^-+/, '' ) // trim - from start of text
+    .replace( /-+$/, '' ) // trim - from end of text
+    .substring( 0, 24 );
+}

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -215,6 +215,7 @@ export default {
             description: cat.description,
             edit: editing[cat.slug],
             draggable: orderEdit,
+            droppable: false,
             isGroup: false,
           };
         } );
@@ -243,6 +244,7 @@ export default {
             nav: categoryGroup.nav,
             edit: editing[categoryGroup.nav],
             draggable: false,
+            droppable: false,
             isGroup: false,
           } );
         }
@@ -297,9 +299,9 @@ export default {
 
       // Used to indicate something is being edited
       const newCat = {
-        name: '',
-        title: '',
-        description: '',
+        name: 'Name',
+        title: 'Title',
+        description: 'Description',
       };
       Vue.set( this.editing, nav, newCat );
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -275,19 +275,19 @@ export default {
       this.orderEdit = true;
       this.editing = {};
     },
-    saveOrdering() {
+    async saveOrdering() {
 
       // get category ordering.
       const categoryOrdering = getCategoryOrdering( this.categoryTree.tree );
-
-      this.$store.dispatch( 'forum/editCategoryOrdering', categoryOrdering )
-        .then( () => {
-          this.orderEdit = false;
-          this.$nextTick( () => this.$store.dispatch( 'forum/fetch' ) );
-        }, ( err ) => {
-          console.error( err );
-          this.orderEdit = false;
-        } );
+      try {
+        await this.$store.dispatch( 'forum/editCategoryOrdering', categoryOrdering );
+        await this.$store.dispatch( 'forum/fetch' );
+        await this.$store.dispatch( 'categories/fetchAll' );
+      } catch ( err ) {
+        console.error( err );
+      } finally {
+        this.orderEdit = false;
+      }
     },
     cancelOrdering() {
       this.orderEdit = false;
@@ -314,22 +314,22 @@ export default {
         Vue.set( this.editing, slug, null );
       }
     },
-    add( nav ) {
-      this.$store.dispatch( 'categories/add', {
-        name: this.editing[nav].name,
-        title: this.editing[nav].title,
-        description: this.editing[nav].description,
-        nav,
-      } )
-        .then( () => {
-          this.editing[nav] = null;
-          this.$nextTick( () => this.$store.dispatch( 'forum/fetch' ) );
-          this.$nextTick( () => this.$store.dispatch( 'categories/fetchAll' ) );
-        } )
-        .catch( ( err ) => {
-          console.error( err );
-          this.fetching = false;
+    async add( nav ) {
+      try {
+        await this.$store.dispatch( 'categories/add', {
+          name: this.editing[nav].name,
+          title: this.editing[nav].title,
+          description: this.editing[nav].description,
+          nav,
         } );
+        this.editing[nav] = null;
+        await this.$store.dispatch( 'forum/fetch' );
+        await this.$store.dispatch( 'categories/fetchAll' );
+      } catch ( err ) {
+        console.error( err );
+      } finally {
+        this.fetching = false;
+      }
     },
     save( slug ) {
       this.$store.dispatch( 'categories/edit', this.editing[slug] )

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -6,189 +6,190 @@
       Categories
     </h3>
 
-    <b-table
-      class="setting-page"
-      :data="categoryRows"
-      mobile-cards
-    >
-      <template slot-scope="props">
-        <b-table-column
-          field="slug"
-          label="Slug"
-        >
-          {{ props.row.slug }}
-        </b-table-column>
-
-        <b-table-column
-          field="name"
-          label="Name"
-        >
-          <b-field
-            v-if="props.row.edit"
-          >
-            <b-input
-              v-model="props.row.edit.name"
-              :maxlength="32"
-              :has-counter="false"
-            />
-          </b-field>
-          <div
-            v-else
-          >
-            {{ props.row.name }}
-          </div>
-        </b-table-column>
-        <b-table-column
-          field="title"
-          label="Title"
-        >
-          <b-field
-            v-if="props.row.edit"
-          >
-            <b-input
-              v-model="props.row.edit.title"
-              :maxlength="32"
-              :has-counter="false"
-            />
-          </b-field>
-          <div
-            v-else
-          >
-            {{ props.row.title }}
-          </div>
-        </b-table-column>
-        <b-table-column
-          field="description"
-          label="Description"
-        >
-          <b-field
-            v-if="props.row.edit"
-          >
-            <b-input
-              v-model="props.row.edit.description"
-              :maxlength="320"
-              :has-counter="false"
-            />
-          </b-field>
-          <div
-            v-else
-          >
-            {{ props.row.description }}
-          </div>
-        </b-table-column>
-        <b-table-column
-          label="Action"
-          width="150"
-        >
-          <button
-            v-if="props.row.edit"
-            class="button is-small"
-            style="min-width: 40px; max-width: 40px ; width: 40px"
-            :class="{ 'is-loading': fetching }"
-            :disabled="fetching"
-            @click="save(props.row.slug)"
-          >
-            Save
-          </button>
-          <button
-            class="button is-small"
-            style="min-width: 40px; max-width: 40px ; width: 40px"
-            :class="{ 'is-loading': fetching }"
-            :disabled="fetching"
-            @click="toggleEdit(props.row.slug)"
-          >
-            <div v-if="props.row.edit">
-              Cancel
-            </div>
-            <div v-else>
-              Edit
-            </div>
-          </button>
-        </b-table-column>
-        <!--
-        <b-table-column label="Delete" centered>
-
-          <a class="button is-small"
-            :class="{ 'is-loading': fetching }"
-            @click="remove(props.row.id)">
-            <b-icon
-              icon="close-circle"
-              size="is-small">
-            </b-icon>
-          </a>
-        </b-table-column>
-        -->
-      </template>
-    </b-table>
-
-    <hr>
-
-    <h3 class="title">
-      Add a category
-    </h3>
-
-    <form @submit.prevent="add">
-      <b-field label="Category Name">
-        <b-input
-          v-model="name"
-          :maxlength="32"
-          :has-counter="false"
+    <div class="card-content content">
+      <div v-if="orderEdit">
+        <button
+          class="button is-small"
+          :class="{ 'is-loading': fetching }"
           :disabled="fetching"
-        />
-      </b-field>
-
-      <b-field label="Category Title">
-        <b-input
-          v-model="title"
-          :maxlength="32"
-          :has-counter="false"
+          @click="saveOrdering()"
+        >
+          Save Ordering
+        </button>
+        <button
+          class="button is-small"
+          :class="{ 'is-loading': fetching }"
           :disabled="fetching"
-        />
-      </b-field>
-
-      <b-field label="Category Description">
-        <b-input
-          v-model="description"
-          :maxlength="320"
-          :has-counter="false"
-          :disabled="fetching"
-        />
-      </b-field>
-
-      <button
-        role="submit"
-        class="button is-small"
-        :class="{ 'is-loading': fetching }"
-        :disabled="fetching"
+          @click="cancelOrdering()"
+        >
+          Cancel
+        </button>
+      </div>
+      <div v-else>
+        <button
+          class="button is-small"
+          :class="{ 'is-loading': fetching }"
+          :disabled="fetching || activeEdits"
+          @click="enableOrderingEdit()"
+        >
+          Modify Order
+        </button>
+      </div>
+      <Tree
+        :data="[ categoryTree.tree ]"
+        draggable
       >
-        Add Category
-      </button>
-    </form>
+        <template slot-scope="props">
+          <div
+            v-if="props.data.isGroup"
+            class="is-tablet box cat-style"
+          >
+            {{ props.data.name }}
+            <a
+              class=""
+              @click="props.store.toggleOpen( props.data )"
+            >
+              <b-icon
+                :icon="props.data.open ? 'menu-up' : 'menu-down'"
+              />
+            </a>
+            <div v-if="props.data.open">
+              <button
+                class="button is-small"
+                :class="{ 'is-loading': fetching }"
+                :disabled="fetching"
+                @click="addCategoryToGroup(props.data.nav)"
+              >
+                Add Category
+              </button>
+            </div>
+          </div>
+          <div
+            v-else
+            class="columns is-tablet box cat-style"
+          >
+            <div class="column cat-stats">
+              <span class="cprops-title">{{ props.data.slug }}</span>
+            </div>
+            <div class="column cat-stats">
+              <b-field
+                v-if="props.data.edit"
+              >
+                <b-input
+                  v-model="props.data.edit.name"
+                  :maxlength="32"
+                  :has-counter="false"
+                />
+              </b-field>
+              <div
+                v-else
+              >
+                {{ props.data.name }}
+              </div>
+            </div>
+            <div class="column cat-stats">
+              <b-field
+                v-if="props.data.edit"
+              >
+                <b-input
+                  v-model="props.data.edit.title"
+                  :maxlength="32"
+                  :has-counter="false"
+                />
+              </b-field>
+              <div
+                v-else
+              >
+                {{ props.data.title }}
+              </div>
+            </div>
+            <div class="column cat-stats">
+              <b-field
+                v-if="props.data.edit"
+              >
+                <b-input
+                  v-model="props.data.edit.description"
+                  :maxlength="320"
+                  :has-counter="false"
+                />
+              </b-field>
+              <div
+                v-else
+              >
+                {{ props.data.description }}
+              </div>
+            </div>
+            <div class="column">
+              <button
+                v-if="props.data.edit"
+                class="button is-small"
+                style="min-width: 40px; max-width: 40px ; width: 40px"
+                :class="{ 'is-loading': fetching }"
+                :disabled="fetching"
+                @click="props.data.slug ? save( props.data.slug ) : add( props.data.nav )"
+              >
+                Save
+              </button>
+              <button
+                class="button is-small"
+                style="min-width: 40px; max-width: 40px ; width: 40px"
+                :class="{ 'is-loading': fetching }"
+                :disabled="fetching || ( !props.data.edit && activeEdits )"
+                @click="props.data.slug ? toggleEdit( props.data.slug ) : cancelAdd( props.data.nav )"
+              >
+                <div v-if="props.data.edit">
+                  Cancel
+                </div>
+                <div v-else>
+                  Edit
+                </div>
+              </button>
+            </div>
+          </div>
+        </template>
+      </Tree>
+    </div>
   </div>
 </template>
 
 <script>
 import Field from 'buefy/src/components/field/Field';
+import Icon from 'buefy/src/components/icon/Icon';
 import Input from 'buefy/src/components/input/Input';
-
-import Table from 'buefy/src/components/table/Table';
-import TableColumn from 'buefy/src/components/table/TableColumn';
+import { DraggableTree } from 'vue-draggable-nested-tree';
 import Vue from 'vue';
 import { mapState } from 'vuex';
+
+function getCategoryOrdering( treeGroup ) {
+  const categories = [];
+  const groups = [];
+  for ( let i = 0; i < treeGroup.children.length; i++ ) {
+    const child = treeGroup.children[i];
+    if ( child.isGroup ) {
+      groups.push( getCategoryOrdering( child ) );
+    } else {
+      categories.push( child.slug );
+    }
+  }
+  return {
+    slug: treeGroup.slug,
+    name: treeGroup.name,
+    categories,
+    groups,
+  };
+}
 
 export default {
   name: 'Settings',
   components: {
-    BTable: Table,
-    BTableColumn: TableColumn,
+    BIcon: Icon,
     BField: Field,
     BInput: Input,
+    Tree: DraggableTree,
   },
   data() {
     return {
-      name: '',
-      title: '',
-      description: '',
+      orderEdit: false,
       editing: {},
     };
   },
@@ -196,7 +197,63 @@ export default {
     ...mapState( 'categories', [
       'categoryList',
       'fetching',
+      'categoriesByBreadcrumb',
     ] ),
+    categoryTree() {
+      if ( !this.categoriesByBreadcrumb ) {
+        return {};
+      }
+      const categoriesBySlug = {};
+      const editing = this.editing;
+      const orderEdit = this.orderEdit;
+      function convertTree( categoryGroup ) {
+        const cats = categoryGroup.categories.map( ( cat ) => {
+          return {
+            slug: cat.slug,
+            name: cat.name,
+            title: cat.title,
+            description: cat.description,
+            edit: editing[cat.slug],
+            draggable: orderEdit,
+            isGroup: false,
+          };
+        } );
+        categoryGroup.categories.forEach( ( cat ) => {
+
+          // copy main properties before Tree modifies
+          // them for rendering
+          categoriesBySlug[cat.slug] = { ...cat };
+        } );
+        const groups = categoryGroup.groups.map( ( g ) => {
+          return convertTree( g );
+        } );
+        const group = {
+          name: categoryGroup.name,
+          slug: categoryGroup.slug,
+          nav: categoryGroup.nav,
+          children: groups.concat( cats ),
+          draggable: orderEdit,
+          isGroup: true,
+        };
+
+        // Check if user added category for this group.
+        if ( editing[categoryGroup.nav] ) {
+          group.children.unshift( {
+            slug: '',
+            nav: categoryGroup.nav,
+            edit: editing[categoryGroup.nav],
+            draggable: false,
+            isGroup: false,
+          } );
+        }
+        return group;
+      }
+      const tree = convertTree( this.categoriesByBreadcrumb );
+      return {
+        tree,
+        categoriesBySlug,
+      };
+    },
     categoryRows() {
       return this.categoryList.map( ( c ) => {
         if ( this.editing[c.slug] ) {
@@ -209,26 +266,64 @@ export default {
 
       } );
     },
+    activeEdits() {
+      return Object.values( this.editing ).filter( ( e ) => e ).length > 0;
+    },
   },
   methods: {
+    enableOrderingEdit() {
+      this.orderEdit = true;
+      this.editing = {};
+    },
+    saveOrdering() {
+
+      // get category ordering.
+      const categoryOrdering = getCategoryOrdering( this.categoryTree.tree );
+
+      this.$store.dispatch( 'forum/editCategoryOrdering', categoryOrdering )
+        .then( () => {
+          this.orderEdit = false;
+          this.$nextTick( () => this.$store.dispatch( 'forum/fetch' ) );
+        }, ( err ) => {
+          console.error( err );
+          this.orderEdit = false;
+        } );
+    },
+    cancelOrdering() {
+      this.orderEdit = false;
+      this.$store.dispatch( 'categories/fetchAll' );
+    },
+    addCategoryToGroup( nav ) {
+
+      // Used to indicate something is being edited
+      const newCat = {
+        name: '',
+        title: '',
+        description: '',
+      };
+      Vue.set( this.editing, nav, newCat );
+    },
+    cancelAdd( nav ) {
+      Vue.set( this.editing, nav, null );
+    },
     toggleEdit( slug ) {
-      const thisCategory = this.categoryList.find( ( c ) => c.slug === slug );
+      const thisCategory = this.categoryTree.categoriesBySlug[slug];
       if ( !this.editing[slug] ) {
         Vue.set( this.editing, slug, { ...thisCategory } );
       } else {
         Vue.set( this.editing, slug, null );
       }
     },
-    add() {
+    add( nav ) {
       this.$store.dispatch( 'categories/add', {
-        name: this.name,
-        title: this.title,
-        description: this.description,
+        name: this.editing[nav].name,
+        title: this.editing[nav].title,
+        description: this.editing[nav].description,
+        nav,
       } )
         .then( () => {
-          this.name = '';
-          this.title = '';
-          this.description = '';
+          this.editing[nav] = null;
+          this.$nextTick( () => this.$store.dispatch( 'forum/fetch' ) );
           this.$nextTick( () => this.$store.dispatch( 'categories/fetchAll' ) );
         } )
         .catch( ( err ) => {


### PR DESCRIPTION
Uses draggable component to set it up.

1. Only allows one type of mutation at a time.
2. Hitting 'modify category order' allows the nodes to be draggable. After things have been dragged around, can hit 'save' to trigger order save.

![Screenshot 2019-05-06 at 11 47 39 PM](https://user-images.githubusercontent.com/34953718/57270591-fe28d580-7059-11e9-9b6b-98954a18fa17.png)

is how it looks now, some styling to be desired.