### PR TITLE
Trigger reactivity for category list after adjustment

### DIFF
--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -5,6 +5,7 @@ import { errorAlertOptions } from '../utils/notifications.js';
 import { stringToSlug } from '../utils/slug.js';
 
 import map from 'lodash/map';
+import Vue from 'vue';
 
 function computeCategoryOrderingData( state, categoryOrdering ) {
   const categoriesBySlug = {};

--- a/src/store/categories.store.js
+++ b/src/store/categories.store.js
@@ -99,6 +99,7 @@ export default {
     },
     updateCategoryOrderingData( state ) {
       computeCategoryOrderingData( state, this.getters['forum/getCategoryOrdering'] );
+      Vue.set( state, 'categoryList', state.categoryList );
     },
   },
   actions: {


### PR DESCRIPTION
Symptom: breadcrumb missing for certain categories, e.g. https://bitsports.tokenbb.io/topic-list?category=football-gossip

Note: suspect many instances of Vue.set not being used properly, since I think it needs the second argument to be a string