### PR TITLE
Add endpoint for forum list with preliminary explorer, also forum settings modifier

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,10 @@ export default {
           const page = this.$route.query.page ? this.$route.query.page : 1;
           const pageSize = this.$route.query.page_size ? this.$route.query.page_size : 10;
           await this.$store.dispatch( 'topics/fetchAll', { category, page, pageSize } );
+        } else if ( this.$route.path.startsWith( '/forums' ) ) {
+          const page = this.$route.query.page ? this.$route.query.page : 1;
+          const pageSize = this.$route.query.page_size ? this.$route.query.page_size : 10;
+          await this.$store.dispatch( 'forum/fetchForums', { page, pageSize } );
         }
         this.loaded = true;
       } catch ( err ) {

--- a/src/router.js
+++ b/src/router.js
@@ -18,6 +18,12 @@ const router = new Router( {
       component: loadView( 'Home' ),
     },
     {
+      path: '/forums',
+      name: 'forums',
+      component: loadView( 'ForumList' ),
+    },
+
+    {
       path: '/topic-list',
       name: 'topic-list',
       component: loadView( 'TopicList' ),

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -411,3 +411,14 @@ export function modifyForumPermission( action, type, username ) {
   };
   return requestAsync( opts );
 }
+
+export function patchForum( forum ) {
+  const opts = {
+    method: 'POST',
+    json: true,
+    headers: steem.token ? { 'Authorization': 'Bearer ' + steem.token } : {},
+    url: `${apiURL()}/patch`,
+    body: forum,
+  };
+  return requestAsync( opts );
+}

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -36,8 +36,12 @@ export function getScotTokenPayout( author, permlink ) {
   return requestAsync( opts );
 }
 
+export function baseApiUrl() {
+  return `${process.env.VUE_APP_API_HOST}/v1`;
+}
+
 export function apiURL() {
-  return `${process.env.VUE_APP_API_HOST}/v1/forum/${global.forumname}`;
+  return `${baseApiUrl()}/forum/${global.forumname}`;
 }
 
 export function uploadImage( image ) {
@@ -125,6 +129,22 @@ export function getDomainForum( domain ) {
       domain,
     },
   };
+  return requestAsync( opts );
+}
+
+export function listForums( args ) {
+  let query = '';
+  if ( args ) {
+    Object.keys( args ).forEach( ( k ) => {
+      query += `${k}=${args[k]}`;
+    } );
+  }
+  const opts = {
+    method: 'GET',
+    json: true,
+    url: `${baseApiUrl()}/forums${query ? '?' + query : ''}`,
+  };
+
   return requestAsync( opts );
 }
 

--- a/src/store/forum.store.js
+++ b/src/store/forum.store.js
@@ -7,6 +7,7 @@ import {
   getUsers,
   modifyForumPermission,
   getTokenIcon,
+  patchForum,
 } from '../services/api.service.js';
 import { errorAlertOptions } from '../utils/notifications.js';
 
@@ -43,6 +44,9 @@ export default {
       split: [],
     },
     forumList: [],
+    name: '',
+    description: '',
+    discoverable: false,
   },
   mutations: {
     setTokenIcon( state, icon ) {
@@ -90,7 +94,13 @@ export default {
           weight: btWeight,
         } );
       }
+      state.name = forum.name;
+      state.description = forum.description;
+      state.discoverable = forum.discoverable;
       this.commit( 'categories/updateCategoryList' );
+    },
+    updateForumProperty( state, property ) {
+      state[property.name] = property.value;
     },
   },
   getters: {
@@ -165,6 +175,19 @@ export default {
     },
     async removeForumMod( { commit }, username ) {
       await sendModifyForumPermission( commit, 'remove', 'mod', username );
+    },
+    async patch( { commit }, forum ) {
+      commit( 'setFetching', true );
+      try {
+        const saved = await patchForum( forum );
+        commit( 'updateForum', saved.data );
+        commit( 'setFetching', false );
+        Toast.open( 'Successfully saved forum settings!' );
+      } catch ( err ) {
+        commit( 'setFetching', false );
+        Toast.open( errorAlertOptions( 'Error patching forum', err ) );
+        console.error( err );
+      }
     },
   },
 };

--- a/src/store/forum.store.js
+++ b/src/store/forum.store.js
@@ -2,6 +2,7 @@ import { ToastProgrammatic as Toast } from 'buefy';
 
 import {
   listRoles,
+  listForums,
   setCategoryOrdering,
   getUsers,
   modifyForumPermission,
@@ -41,6 +42,7 @@ export default {
       topic_starter: 0,
       split: [],
     },
+    forumList: [],
   },
   mutations: {
     setTokenIcon( state, icon ) {
@@ -48,6 +50,9 @@ export default {
     },
     setFetching( state, fetching ) {
       state.fetching = fetching;
+    },
+    updateForumList( state, forumList ) {
+      state.forumList = forumList;
     },
     updateForum( state, forum ) {
       try {
@@ -122,6 +127,19 @@ export default {
       } catch ( err ) {
         commit( 'setFetching', false );
         Toast.open( errorAlertOptions( 'Error fetching forum', err ) );
+        console.error( err );
+      }
+    },
+    async fetchForums( { commit, state }, args ) {
+      commit( 'setFetching', true );
+
+      try {
+        const forumList = await listForums( args );
+        commit( 'updateForumList', forumList.data );
+        commit( 'setFetching', false );
+      } catch ( err ) {
+        commit( 'setFetching', false );
+        Toast.open( errorAlertOptions( 'Error fetching forum list', err ) );
         console.error( err );
       }
     },

--- a/src/themes/bitsports.scss
+++ b/src/themes/bitsports.scss
@@ -509,12 +509,12 @@
     padding: 0 !important;
   }
 
-  .card-content .box span {
+  .card-content span {
     font-size: 16px;
     color: #FFC046;
   }
 
-  .card-content .box span.cprops-title {
+  .card-content span.cprops-title {
     font-size: 20px;
     font-weight: 900;
     color: $content;

--- a/src/themes/droneshot.scss
+++ b/src/themes/droneshot.scss
@@ -445,12 +445,12 @@
     padding: 0 !important;
   }
 
-  .card-content .box span {
+  .card-content span {
     font-size: 16px;
     color: #45484e;
   }
 
-  .card-content .box span.cprops-title {
+  .card-content span.cprops-title {
     font-size: 20px;
     font-weight: 600;
     color: #384a66;

--- a/src/themes/monsters.scss
+++ b/src/themes/monsters.scss
@@ -432,12 +432,12 @@
     padding: 0 !important;
   }
 
-  .card-content .box span {
+  .card-content span {
     font-size: 16px;
     color: #FFEDA0;
   }
 
-  .card-content .box span.cprops-title {
+  .card-content span.cprops-title {
     font-size: 20px;
     font-weight: 600;
     color: $content;

--- a/src/themes/nextcolony.scss
+++ b/src/themes/nextcolony.scss
@@ -443,12 +443,12 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1affffff', e
     padding: 0 !important;
   }
 
-  .card-content .box span {
+  .card-content span {
     font-size: 16px;
     color: #FFFFFF;
   }
 
-  .card-content .box span.cprops-title {
+  .card-content span.cprops-title {
     font-size: 20px;
     font-weight: 600;
     color: $content;

--- a/src/themes/steem.scss
+++ b/src/themes/steem.scss
@@ -462,12 +462,12 @@
     padding: 0 !important;
   }
 
-  .card-content .box span {
+  .card-content span {
     font-size: 16px;
     color: #fff;
   }
 
-  .card-content .box span.cprops-title {
+  .card-content span.cprops-title {
     font-size: 20px;
     font-weight: 600;
     color: $content;

--- a/src/views/ForumList.vue
+++ b/src/views/ForumList.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="container home">
+    <div>
+      <div class="card-content">
+        <div class="content">
+          <b-table
+            :loading="fetching"
+            :data="forumList"
+            class=""
+            :paginated="true"
+            :per-page="10"
+            default-sort-direction="desc"
+            default-sort="meta.views"
+          >
+            <template slot-scope="cprops">
+              <b-table-column
+                field="name"
+                label="Name"
+                class="card"
+                sortable
+              >
+                <template
+                  slot="header"
+                  slot-scope="{ column }"
+                >
+                  <div class="">
+                    <span>{{ column.label }}</span>
+                  </div>
+                </template>
+                <div class="">
+                  <span class="cprops-title">{{ cprops.row.name }}</span><br>
+                </div>
+              </b-table-column>
+              <b-table-column
+                field="meta.topics"
+                label="Topics"
+                class="card"
+                sortable
+              >
+                <template
+                  slot="header"
+                  slot-scope="{ column }"
+                >
+                  <div class="">
+                    <span>{{ column.label }}</span>
+                  </div>
+                </template>
+                <div class="column cat-stats">
+                  <span>{{ cprops.row.meta ? cprops.row.meta.topics : '' }} Topics</span>
+                </div>
+              </b-table-column>
+              <b-table-column
+                field="meta.views"
+                label="Views"
+                class="card"
+                sortable
+              >
+                <template
+                  slot="header"
+                  slot-scope="{ column }"
+                >
+                  <div class="">
+                    <span>{{ column.label }}</span>
+                  </div>
+                </template>
+                <div class="column cat-stats">
+                  <span>{{ cprops.row.meta ? cprops.row.meta.views : '' }} Views</span>
+                </div>
+              </b-table-column>
+            </template>
+          </b-table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import { mapState } from 'vuex';
+
+import Table from 'buefy/src/components/table/Table';
+import TableColumn from 'buefy/src/components/table/TableColumn';
+
+export default {
+  name: 'ForumList',
+  components: {
+    BTable: Table,
+    BTableColumn: TableColumn,
+  },
+  computed: {
+    ...mapState( 'forum', [
+      'forumList',
+      'fetching',
+    ] ),
+  },
+  beforeRouteUpdate( to, from, next ) {
+    const page = to.query.page ? to.query.page : 1;
+    const pageSize = to.query.page_size ? to.query.page_size : null;
+    this.$store.dispatch( 'forum/fetchForums', { page, pageSize } );
+    next();
+  },
+};
+</script>
+

--- a/src/views/ForumList.vue
+++ b/src/views/ForumList.vue
@@ -28,7 +28,11 @@
                   </div>
                 </template>
                 <div class="">
-                  <span class="cprops-title">{{ cprops.row.name }}</span><br>
+                  <span class="cprops-title">
+                    <a
+                      :href="cprops.row.steem.canonical"
+                      target="_blank"
+                    >{{ cprops.row.name }}</a></span><br>
                 </div>
               </b-table-column>
               <b-table-column

--- a/src/views/admin/Settings.vue
+++ b/src/views/admin/Settings.vue
@@ -1,18 +1,105 @@
 <template>
   <AdminNav>
-    <div class="container column is-10">
-      <div class="section">
-        <h2 class="sub-header">
-          Feature Coming Soon™
-        </h2>
+    <div class="container column">
+      <div class="dashboard__section">
+        <section>
+          <h2 class="sub-header">
+            Update Forum
+          </h2>
+          <form
+            class="dashboard__form"
+            @submit.prevent="patchForum"
+          >
+            <b-field
+              horizontal
+              class="input-title"
+              label="Name"
+            >
+              <b-input
+                :value="name"
+                placeholder="Type name here"
+                class=""
+                @input="updateName"
+              />
+            </b-field>
+            <b-field
+              horizontal
+              class="input-title"
+              label="Description"
+            >
+              <b-input
+                :value="description"
+                placeholder="Type description here"
+                class=""
+                @input="updateDescription"
+              />
+            </b-field>
+            <b-field
+              horizontal
+              class="input-title"
+              label="Discoverable"
+            >
+              <b-checkbox
+                :value="discoverable"
+                @input="updateDiscoverable"
+              />
+            </b-field>
+            <button
+              role="submit"
+              :class="{ 'is-loading': fetching }"
+              class="button is-small save"
+            >
+              Save
+            </button>
+          </form>
+        </section>
       </div>
     </div>
   </AdminNav>
 </template>
 <script>
 import AdminNav from '../../components/admin/AdminNav.vue';
+import Checkbox from 'buefy/src/components/checkbox/Checkbox';
+import Field from 'buefy/src/components/field/Field';
+import Input from 'buefy/src/components/input/Input';
+import { mapState } from 'vuex';
 
 export default {
-  components: { AdminNav },
+  name: 'Settings',
+  components: {
+    AdminNav,
+    BCheckbox: Checkbox,
+    BField: Field,
+    BInput: Input,
+  },
+  computed: {
+    ...mapState( 'forum', [ 'name', 'description', 'discoverable', 'fetching' ] ),
+  },
+  mounted() {
+    this.$store.dispatch( 'forum/fetch', /* withModData= */ false );
+  },
+  methods: {
+    async patchForum() {
+      const patch = {
+        name: this.name,
+        description: this.description,
+        discoverable: this.discoverable,
+      };
+      try {
+        await this.$store.dispatch( 'forum/patch', patch );
+      } catch ( err ) {
+        console.error( err );
+      }
+    },
+    updateName( value ) {
+      this.$store.commit( 'forum/updateForumProperty', { name: 'name', value } );
+    },
+    updateDescription( value ) {
+      this.$store.commit( 'forum/updateForumProperty', { name: 'description', value } );
+    },
+    updateDiscoverable( value ) {
+      this.$store.commit( 'forum/updateForumProperty', { name: 'discoverable', value } );
+    },
+  },
 };
 </script>


### PR DESCRIPTION
1. Allow modification of forum name, description, and discoverable toggle.
2. Show discoverable forums in forum explorer. Basic sorting/paging on FE only.

Requires https://github.com/BuildTeamDev/buildteam-api/pull/223